### PR TITLE
Add action for syncing current formula with its versioned equivalent

### DIFF
--- a/.github/workflows/sync-versioned-formula.yml
+++ b/.github/workflows/sync-versioned-formula.yml
@@ -1,0 +1,15 @@
+name: Sync versioned formulas
+
+on: [pull_request]
+
+jobs:
+  sync_versioned_formula:
+    name: Sync current version of formula to a versioned formula
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      - name: Sync supergrain-cli
+        shell: bash
+        run: ./scripts/sync_versioned_formula.sh supergrain-cli

--- a/.github/workflows/sync-versioned-formula.yml
+++ b/.github/workflows/sync-versioned-formula.yml
@@ -13,3 +13,9 @@ jobs:
       - name: Sync supergrain-cli
         shell: bash
         run: ./scripts/sync_versioned_formula.sh supergrain-cli
+
+      - name: Commit any new formulas
+        uses: EndBug/add-and-commit@v7
+        with:
+          message: 'Sync versioned formula'
+          add: 'Formula/*.rb'

--- a/scripts/sync_versioned_formula.sh
+++ b/scripts/sync_versioned_formula.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+
+set -euo pipefail
+
+DIR="$( cd -P "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+FORMULA_DIR=$DIR/../Formula
+
+# See if we should use gsed or sed.
+if command -v gsed 1> /dev/null 2> /dev/null ; then
+  SED=gsed
+elif command -v sed 1> /dev/null 2> /dev/null ; then
+  SED=sed
+else
+  echo "This script requires sed, no sed found."
+  exit 1
+fi
+
+# this script ensures that the current formula has an associated "versioned" formula.
+# it is meant to be used for pull requests that automatically update the formula
+# to a new version and is ultimately meant to enable users to do:
+#   brew install formula@some-version
+
+function current_version {
+  formula_name="${1}"
+  formula_path="${FORMULA_DIR}/${formula_name}.rb"
+  
+  grep url "${formula_path}" | \
+    head -n1 | \
+    awk '{print $2}' | \
+    sed 's/"//g' | \
+    rev | \
+    cut -d '-' -f1 | \
+    rev | \
+    sed 's/.tar.gz//g'
+}
+
+function sync_formula {
+  formula_name="${1}"
+  formula_path="${FORMULA_DIR}/${formula_name}.rb"
+
+  if [ ! -e "${FORMULA_DIR}/${formula_name}.rb" ]; then
+    echo "formula ${formula_name} does not exist, exiting"
+    exit 1
+  fi
+
+  # get current version from formula
+  current_version="$(current_version "${formula_name}")"
+
+  # remove v prefix
+  current_version="${current_version#v}"
+
+  versioned_formula_path="${FORMULA_DIR}/${formula_name}@${current_version}.rb"
+  # if it already exists, we're done
+  if [ -e "${versioned_formula_path}" ]; then
+    echo "versioned formula already exists, nothing to do."
+    exit 0
+  fi
+
+  # copy formula to versioned equivalent
+  cp "${formula_path}" "${versioned_formula_path}"
+
+  # translate version to a class suffix with "AT" followed by only numbers
+  # this is what homebrew expects classes to be named when the formula ends in
+  # @0.10.10.rb -> AT01020
+  class_suffix="AT$(echo "${current_version}" | tr -d .)"
+
+  # update class name to match the version name
+  $SED -i -E 's/^class (.*) < Formula$/class \1'${class_suffix}' < Formula/' "${versioned_formula_path}" 
+}
+
+function main {
+  formula_name="${1:-}"
+
+  if [ -z "${formula_name}" ]; then
+    # TODO: sync all?
+    echo "formula name is required."
+    echo "usage: sync_versioned_formula.sh <formula_name>"
+    exit 1
+  else
+    # sync one
+    sync_formula "${formula_name}"
+  fi
+}
+
+main "$@"


### PR DESCRIPTION
This adds a new workflow for new pull requests that will automatically sync the current version of a formula to its "versioned" equivalent. Concretely, this means that if formula `supergrain-cli` refers to v2.0.0 of an archive, the script will ensure that a formula `supergrain-cli@2.0.0.rb` exists. Whenever we bump a formula to a new version, this will make sure that users will be able to go back to it whenever a new one is released. 

Note: I decided to implement this workflow here rather than in `supergrain/supergrain` for two reasons:
1) it is generic to any formula -- if we decide to add another in the future, we just add it to the list here (or extend the script to sync everything).
2) it's simpler to define an Action that operates on the repository that is changing rather than making changes to external repository since tokens are always scoped to the repository that the action is running in.